### PR TITLE
Remove extra code

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,14 +23,7 @@
         <p>We at KendallDoesCoding, wish all of you a Merry Christmas, enjoy your day and make sure you come here and listen to this album
            a couple times during your day. &#128522; </p>
     </div>
-<center>
-<embed>
         <iframe id="embed" width="560" height="315" src="https://www.youtube.com/embed/TtY9eRayseg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</center>
-    </embed>
-    
-
-
     <!-- songs container, its called upon in the js file, thus this is empty. -->
     <div class="songs">
     </div>


### PR DESCRIPTION
#115 was working without the code being closed properly for the embed line, this removes <center> and <embed> as that's extra code since v8.0
